### PR TITLE
[WIP] Allow more general knot sequences

### DIFF
--- a/src/BSplines.jl
+++ b/src/BSplines.jl
@@ -42,7 +42,7 @@ include("plotting.jl")
 
 bspline_returntype(basis::BSplineBasis, x::Number) = bspline_returntype(basis, typeof(x))
 bspline_returntype(basis::BSplineBasis, types::Type...) =
-    bspline_returntype(eltype(breakpoints(basis)), types...)
+    bspline_returntype(eltype(knots(basis)), types...)
 
 bspline_returntype(spline::Spline, x::Number) = bspline_returntype(spline, typeof(x))
 bspline_returntype(spline::Spline, xtype::Type) =
@@ -71,10 +71,10 @@ See also: [`interpolate`](@ref)
 julia> basis = BSplineBasis(5, 0:5);
 
 julia> spl = approximate(sin, basis, indices=2:length(basis))
-Spline{BSplineBasis{UnitRange{Int64}},Array{Float64,1}}:
- basis: 9-element BSplineBasis{UnitRange{Int64}}:
+Spline{BSplineBasis{BSplines.KnotVector{Int64,UnitRange{Int64}}},Array{Float64,1}}:
+ basis: 9-element BSplineBasis{BSplines.KnotVector{Int64,UnitRange{Int64}}}:
   order: 5
-  breakpoints: 0:5
+  knots: [0, 0, 0, 0, 0, 1, 2, 3, 4, 5, 5, 5, 5, 5]
  coeffs: [0.0, 0.24963094468700395, 0.7525104872191076, 1.229735980709192, 0.7385208497317045, -0.4328168377896504, -1.0125409246826416, -1.029692234224304, -0.9589242746631385]
 
 julia> spl(π/4)
@@ -105,10 +105,10 @@ julia> basis = BSplineBasis(5, 1:10);
 julia> xs = range(1, stop=10, length=length(basis)); ys = log.(xs);
 
 julia> spl = interpolate(basis, xs, ys)
-Spline{BSplineBasis{UnitRange{Int64}},Array{Float64,1}}:
- basis: 13-element BSplineBasis{UnitRange{Int64}}:
+Spline{BSplineBasis{BSplines.KnotVector{Int64,UnitRange{Int64}}},Array{Float64,1}}:
+ basis: 13-element BSplineBasis{BSplines.KnotVector{Int64,UnitRange{Int64}}}:
   order: 5
-  breakpoints: 1:10
+  knots: [1, 1, 1, 1, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 10, 10]
  coeffs: [0.0, 0.2480193113006778, 0.5968722382485209, 0.9466707785821219, 1.2689430722820556, 1.5140484163988175, 1.7114875128056504, 1.8766572742486973, 2.0185639127626325, 2.1429230073972407, 2.2259183994808813, 2.2775846911059, 2.302585092994046]
 
 julia> spl(float(ℯ))
@@ -264,9 +264,9 @@ optimum” and are computationally inexpensive.
 
 ```jldoctest
 julia> averagebasis(5, 0:10)
-11-element BSplineBasis{Array{Float64,1}}:
+11-element BSplineBasis{BSplines.KnotVector{Float64,Array{Float64,1}}}:
  order: 5
- breakpoints: [0.0, 2.5, 3.5, 4.5, 5.5, 6.5, 7.5, 10.0]
+ knots: [0.0, 0.0, 0.0, 0.0, 0.0, 2.5, 3.5, 4.5, 5.5, 6.5, 7.5, 10.0, 10.0, 10.0, 10.0, 10.0]
 ```
 """
 function averagebasis(order::Integer, datapoints::AbstractVector{<:Real})

--- a/src/spline.jl
+++ b/src/spline.jl
@@ -26,13 +26,13 @@ Spline(basis, coeffs) = Spline{typeof(basis),typeof(coeffs)}(basis, coeffs)
 Base.:(==)(x::Spline, y::Spline) = basis(x) == basis(y) && coeffs(x) == coeffs(y)
 
 Base.hash(x::Spline, h::UInt) =
-    hash(coeffs(x), hash(breakpoints(basis(x)), hash(order(x), hash(:Spline, h))))
+    hash(coeffs(x), hash(knots(basis(x)), hash(order(x), hash(:Spline, h))))
 
 function Base.show(io::IO, ::MIME"text/plain", s::Spline)
     summary(io, s); println(io, ':')
     print(io, " basis: "); summary(io, basis(s)); println(io, ':')
     println(io, "  order: ", order(basis(s)))
-    println(io, "  breakpoints: ", breakpoints(basis(s)))
+    println(io, "  knots: ", knots(basis(s)))
     print(io, " coeffs: ", coeffs(s))
 end
 
@@ -85,8 +85,7 @@ order(s::Spline) = order(basis(s))
 """
     BSpline{B} <: Spline{B}
 
-Type for a B-spline from a B-spline basis of type `B`. `BSpline`s can be obtained by
-indexing into a B-spline basis.
+Type for a B-spline from a B-spline basis of type `B`.
 """
 const BSpline = Spline{B, StandardBasisVector{Bool}} where B<:BSplineBasis
 
@@ -96,18 +95,19 @@ const BSpline = Spline{B, StandardBasisVector{Bool}} where B<:BSplineBasis
 """
     BSpline(basis::BSplineBasis, index)
 
-Return the `index`-th B-spline of `basis`.
+Return the `index`-th B-spline of `basis`. Instead of `BSpline(basis, index)`, the shorthand
+`basis[index]` can be used.
 
 # Example
 
 ```jldoctest
 julia> basis = BSplineBasis(5, 1:10);
 
-julia> BSpline(basis, 3)
-BSpline{BSplineBasis{UnitRange{Int64}}}:
- basis: 13-element BSplineBasis{UnitRange{Int64}}:
+julia> BSpline(basis, 3) # or: basis[3]
+BSpline{BSplineBasis{BSplines.KnotVector{Int64,UnitRange{Int64}}}}:
+ basis: 13-element BSplineBasis{BSplines.KnotVector{Int64,UnitRange{Int64}}}:
   order: 5
-  breakpoints: 1:10
+  knots: [1, 1, 1, 1, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 10, 10]
  index: 3 (knots: [1, 1, 1, 2, 3, 4])
 ```
 """
@@ -121,7 +121,7 @@ function Base.show(io::IO, ::MIME"text/plain", x::BSpline)
     summary(io, x); println(io, ':')
     print(io, " basis: "); summary(io, basis(x)); println(io, ':')
     println(io, "  order: ", order(basis(x)))
-    println(io, "  breakpoints: ", breakpoints(basis(x)))
+    println(io, "  knots: ", knots(basis(x)))
     print(io, " index: ", coeffs(x).index, " (knots: ", bsplineknots(x), ')')
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -127,7 +127,8 @@ end
 
 @testset "intervalindices" begin
     support = [(1, 3:3), (2, 3:4), (3, 3:5), (4, 4:6), (5, 5:7), (6, 6:7), (7, 7:7)]
-    for basis = [BSplineBasis(3, 0:5), BSplineBasis(3, 1//2:1//2:3//1), BSplineBasis(3, 0.0:0.2:1.0)]
+    for basis = [BSplineBasis(3, 0:5), BSplineBasis(3, 1//2:1//2:3//1),
+                 BSplineBasis(3, 0.0:0.2:1.0), BSplineBasis{Vector{Int}}(3, 0:5)]
         @test @inferred(eltype(intervalindices(basis))) === Int
         @test @inferred(eltype(intervalindices(basis))) === Int
         @test collect(intervalindices(basis))      == 3:7
@@ -158,22 +159,25 @@ end
     end
     support = [(1, [4]), (2, [4,5]), (3, [4,5]), (4, [4,5,7]), (5, [5,7,8]),
                (6, [7,8,9]), (7, [7,8,9]), (8, [8,9]), (9, [9])]
-    @test collect(intervalindices(BSplineBasis(4, [1,2,3,3,4,5,6]))) == [4,5,7,8,9]
-    @test collect(intervalindices(BSplineBasis(4, [1,2,3,3,4,5,6]), :)) == [4,5,7,8,9]
-    @test collect(intervalindices(BSplineBasis(4, [1,2,3,3,4,5,6]), 1:9)) == [4,5,7,8,9]
-    @test collect(intervalindices(BSplineBasis(4, [1,2,3,3,4,5,6]), 1:8)) == [4,5,7,8,9]
-    @test collect(intervalindices(BSplineBasis(4, [1,2,3,3,4,5,6]), 4:8)) == [4,5,7,8,9]
-    @test collect(intervalindices(BSplineBasis(4, [1,2,3,3,4,5,6]), 1:6)) == [4,5,7,8,9]
-    @test collect(intervalindices(BSplineBasis(4, [1,2,3,3,4,5,6]), 5:6)) == [5,7,8,9]
-    @test collect(intervalindices(BSplineBasis(4, [1,2,3,3,4,5,6]), 1:0)) == Int[]
-    @test collect(intervalindices(BSplineBasis(4, [1,2,3,3,4,5,6]), 7:6)) == Int[]
-    for (i, irange) = support
-        @test collect(intervalindices(BSplineBasis(4, [1,2,3,3,4,5,6]), i:i)) == irange
-        @test collect(intervalindices(BSplineBasis(4, [1,2,3,3,4,5,6]), i)) == irange
-        for (j, jrange) = support
-            @test collect(intervalindices(BSplineBasis(4, [1,2,3,3,4,5,6]), i, j)) == irange ∩ jrange
-            for (k, krange) = support
-                @test collect(intervalindices(BSplineBasis(4, [1,2,3,3,4,5,6]), i, j, k)) == irange ∩ jrange ∩ krange
+    for basis = [BSplineBasis(4, [1,2,3,3,4,5,6]),
+                 BSplineBasis{Vector{Float64}}(4, [1,2,3,3,4,5,6])]
+        @test collect(intervalindices(basis)) == [4,5,7,8,9]
+        @test collect(intervalindices(basis, :)) == [4,5,7,8,9]
+        @test collect(intervalindices(basis, 1:9)) == [4,5,7,8,9]
+        @test collect(intervalindices(basis, 1:8)) == [4,5,7,8,9]
+        @test collect(intervalindices(basis, 4:8)) == [4,5,7,8,9]
+        @test collect(intervalindices(basis, 1:6)) == [4,5,7,8,9]
+        @test collect(intervalindices(basis, 5:6)) == [5,7,8,9]
+        @test collect(intervalindices(basis, 1:0)) == Int[]
+        @test collect(intervalindices(basis, 7:6)) == Int[]
+        for (i, irange) = support
+            @test collect(intervalindices(basis, i:i)) == irange
+            @test collect(intervalindices(basis, i)) == irange
+            for (j, jrange) = support
+                @test collect(intervalindices(basis, i, j)) == irange ∩ jrange
+                for (k, krange) = support
+                    @test collect(intervalindices(basis, i, j, k)) == irange ∩ jrange ∩ krange
+                end
             end
         end
     end
@@ -213,9 +217,9 @@ end
              BSplineBasis(3, 0//1:1//1:5//1),
              BSplineBasis(3, 0:0.5:5),
              BSplineBasis(4, 0:5),
-             BSplineBasis(3, [1,2,3,3,4,5])]
+             BSplineBasis(3, [0,1,2,3,3,4,5])]
     for b1 = bases, b2 = bases
-        @test (b1 == b2) == (order(b1) == order(b2) && breakpoints(b1) == breakpoints(b2))
+        @test (b1 == b2) == (order(b1) == order(b2) && knots(b1) == knots(b2))
         @test (b1 == b2) == (hash(b1) == hash(b2))
     end
 end
@@ -280,9 +284,9 @@ end
     @testset "Indexing and iteration" begin
         b1 = BSplineBasis(5, 0:5)
         @test collect(b1) == [b1[i] for i=1:9]
-        @test @inferred(first(b1)) isa BSpline{BSplineBasis{UnitRange{Int}}}
-        @test @inferred(last(b1)) isa BSpline{BSplineBasis{UnitRange{Int}}}
-        @test @inferred(b1[1]) isa BSpline{BSplineBasis{UnitRange{Int}}}
+        @test @inferred(first(b1)) isa BSpline{BSplineBasis{KnotVector{Int,UnitRange{Int}}}}
+        @test @inferred(last(b1)) isa BSpline{BSplineBasis{KnotVector{Int,UnitRange{Int}}}}
+        @test @inferred(b1[1]) isa BSpline{BSplineBasis{KnotVector{Int,UnitRange{Int}}}}
         @test first(b1) == Spline(b1, [1,0,0,0,0,0,0,0,0])
         @test last(b1) == Spline(b1, [0,0,0,0,0,0,0,0,1])
         @test b1[5] == Spline(b1, [0,0,0,0,1,0,0,0,0])
@@ -291,9 +295,9 @@ end
         @test_throws BoundsError b1[10]
         b2 = BSplineBasis(3, [1,2,3.5,6,10])
         @test collect(b2) == [b2[i] for i=1:6]
-        @test @inferred(first(b2)) isa BSpline{BSplineBasis{Vector{Float64}}}
-        @test @inferred(last(b2)) isa BSpline{BSplineBasis{Vector{Float64}}}
-        @test @inferred(b2[1]) isa BSpline{BSplineBasis{Vector{Float64}}}
+        @test @inferred(first(b2)) isa BSpline{BSplineBasis{KnotVector{Float64,Vector{Float64}}}}
+        @test @inferred(last(b2)) isa BSpline{BSplineBasis{KnotVector{Float64,Vector{Float64}}}}
+        @test @inferred(b2[1]) isa BSpline{BSplineBasis{KnotVector{Float64,Vector{Float64}}}}
         @test first(b2) == Spline(b2, [1,0,0,0,0,0])
         @test last(b2) == Spline(b2, [0,0,0,0,0,1])
         @test b2[5] == Spline(b2, [0,0,0,0,1,0])
@@ -304,12 +308,17 @@ end
 
     @testset "breakpoints" begin
         @test breakpoints(BSplineBasis(5, 0:5)) == 0:5
-        @test breakpoints(BSplineBasis(3, [1,2,3,4,4,5])) == [1,2,3,4,4,5]
+        bpts1 = [1,2,3,4,5]
+        @test breakpoints(BSplineBasis(3, bpts1)) == bpts1
+        @test breakpoints(BSplineBasis(3, bpts1)) !== bpts1
+        bpts2 = [1,2,3,4,4,5]
+        @test breakpoints(BSplineBasis(3, bpts2)) == bpts1
     end
 
     @testset "knots" begin
-        @test knots(BSplineBasis(3, 0:5)) == [0, 0, 0, 1, 2, 3, 4, 5, 5, 5]
-        @test knots(BSplineBasis(2, [1.5, 4.0])) == [1.5, 1.5, 4.0, 4.0]
+        @test knots(BSplineBasis(3, 0:5)) === KnotVector(0:5, 2)
+        bpts = [1.5, 4.0]
+        @test knots(BSplineBasis(2, bpts)) === KnotVector(bpts, 1)
     end
 
     @testset "order" begin
@@ -320,8 +329,8 @@ end
     end
 
     @testset "Printing" begin
-        @test summary(BSplineBasis(5, 0:5)) == "9-element BSplineBasis{UnitRange{$Int}}"
-        @test summary(BSplineBasis(8, [1.0:0.1:3.0;])) == "27-element BSplineBasis{$(Vector{Float64})}"
+        @test summary(BSplineBasis(5, 0:5)) == "9-element BSplineBasis{KnotVector{$Int,UnitRange{$Int}}}"
+        @test summary(BSplineBasis(8, [1.0:0.1:3.0;])) == "27-element BSplineBasis{KnotVector{Float64,$(Vector{Float64})}}"
     end
 end
 
@@ -359,6 +368,7 @@ end
                    BSplineBasis(4, 0:4)[1],
                    BSpline(BSplineBasis(4, 0:4), 1),
                    Spline(BSplineBasis(4, [0,1,2,3,4]), [1,0,0,0,0,0,0]),
+                   Spline(BSplineBasis(4, [0,1,2,2,4]), [1,0,0,0,0,0,0]),
                    BSplineBasis(4, 0:5)[1],
                    BSplineBasis(4, Float64[0:5;])[2]]
         for s1 = splines, s2 = splines
@@ -653,7 +663,7 @@ end
 
 @testset "averagebasis" begin
     ≈ₜₑₛₜ(x::BSplineBasis, y::BSplineBasis; kwargs...) =
-        order(x) == order(y) && isapprox(breakpoints(x), breakpoints(y); kwargs...)
+        order(x) == order(y) && isapprox(knots(x), knots(y); kwargs...)
 
     @test averagebasis(3, [0.0, 0.5, 1.5, 2.5, 3.5, 4.5, 5.0]) ≈ₜₑₛₜ BSplineBasis(3, 0:5)
     @test averagebasis(3, [0//1, 1//2, 3//2, 5//2, 7//2, 9//2, 5//1]) == BSplineBasis(3, 0:5)


### PR DESCRIPTION
This PR attempts to implement support for knot sequences where the first and last breakpoints appear less than `order(basis)` times. It is currently work in progress, and at a very early stage.

- [x] Store knots instead of breakpoints in `BSplineBasis`
- [ ] Add a constructor with keyword arguments to be able to specify the knot vector instead of the breakpoints: `BSplineBasis(k, knots=...)` and `BSplineBasis(k, breakpoints=...)`. Deprecate the old (non-keyword) constructor.
- [ ] Allow indexing into a `BSplineBasis` with a `UnitRange` to create a new `BSplineBasis`. Support `view` as well.
- [ ] Modify `bsplines`/`bsplines!`/`splinevalue` to work with the new knot vectors.
- [ ] Deprecate `indices` keyword argument, recommend to use `view(::BSplineBasis, ...)` instead.
- [ ] Update documentation