### PR TITLE
Add specialized copy methods for vector types

### DIFF
--- a/src/vectortypes.jl
+++ b/src/vectortypes.jl
@@ -56,10 +56,13 @@ julia> BSplines.KnotVector(["first", "second", "last"], 2, 3)
     @boundscheck checkbounds(p, i)
     @inbounds parent(p)[clamp(i-p.front, 1, length(parent(p)))]
 end
+Base.getindex(p::KnotVector, ::Colon) = copy(p)
 
 Base.IndexStyle(p::KnotVector) = IndexLinear()
 Base.parent(p::KnotVector) = p.parent
 Base.size(p::KnotVector) = (length(parent(p)) + p.front + p.back,)
+
+Base.copy(p::KnotVector) = @inbounds KnotVector(copy(parent(p)), p.front, p.back)
 
 Base.first(p::KnotVector) = @inbounds first(parent(p))
 Base.last(p::KnotVector) = @inbounds last(parent(p))
@@ -126,10 +129,13 @@ julia> BSplines.StandardBasisVector(Float64, 6, 2)
 
 Base.size(A::StandardBasisVector) = (A.length,)
 
+Base.copy(A::StandardBasisVector) = A
+
 @inline @propagate_inbounds function Base.getindex(A::StandardBasisVector, i::Int)
     @boundscheck checkbounds(A, i)
     convert(eltype(A), i == A.index)
 end
+Base.getindex(A::StandardBasisVector, ::Colon) = A
 
 Base.:(==)(x::StandardBasisVector, y::StandardBasisVector) =
     (x.length == y.length) & (x.index == y.index)

--- a/test/knotvector.jl
+++ b/test/knotvector.jl
@@ -22,6 +22,14 @@
         @test_throws ArgumentError KnotVector(OffsetArray(1:5, 1), 2)
     end
 
+    @testset "copy" begin
+        @test copy(KnotVector(1:5, 2)) === KnotVector(1:5, 2)
+        a = KnotVector([1,2,3], 1, 2)
+        @test a == copy(a)
+        @test a !== copy(a)
+        @test typeof(a) === typeof(copy(a))
+    end
+
     @testset "Dimensions" begin
         @test axes(KnotVector(1:5, 3)) == (1:11,)
         @test axes(KnotVector(1:5, 3), 1) == 1:11
@@ -65,7 +73,7 @@
         @test first(KnotVector([1.0, 4.0], 2, 1)) == 1.0
         @test last(KnotVector(1:5, 3)) == 5
         @test last(KnotVector([1.0, 4.0], 2, 1)) == 4.0
-        @test KnotVector(1:5, 3)[:] == [1, 1, 1, 1, 2, 3, 4, 5, 5, 5, 5]
+        @test KnotVector(1:5, 3)[:] === KnotVector(1:5, 3)
         @test KnotVector(1:5, 3)[1] == 1
         @test KnotVector(1:5, 3)[5] == 2
         @test KnotVector(1:5, 3)[end] == 5
@@ -77,7 +85,10 @@
         @test_throws BoundsError KnotVector(1:5, 3)[1,2]
         @test_throws BoundsError KnotVector(1:5, 3)[1:5,2]
         @test_throws BoundsError KnotVector(1:5, 3)[1:20,1]
-        @test KnotVector([1.0, 4.0], 2, 1)[:] == [1.0, 1.0, 1.0, 4.0, 4.0]
+        @test KnotVector([1.0, 4.0], 2, 1)[:] == KnotVector([1.0, 4.0], 2, 1)
+        @test KnotVector([1.0, 4.0], 2, 1)[:] !== KnotVector([1.0, 4.0], 2, 1)
+        @test parent(KnotVector([1.0, 4.0], 2, 1)[:]) == parent(KnotVector([1.0, 4.0], 2, 1))
+        @test typeof(KnotVector([1.0, 4.0], 2, 1)[:]) === typeof(KnotVector([1.0, 4.0], 2, 1))
         @test KnotVector([1.0, 4.0], 2, 1)[1] == 1.0
         @test KnotVector([1.0, 4.0], 2, 1)[4] == 4.0
         @test KnotVector([1.0, 4.0], 2, 1)[end] == 4.0

--- a/test/standardbasisvector.jl
+++ b/test/standardbasisvector.jl
@@ -18,6 +18,11 @@
         end
     end
 
+    @testset "copy" begin
+        @test copy(StandardBasisVector(5, 2)) === StandardBasisVector(5, 2)
+        @test copy(StandardBasisVector(Float64, 5, 2)) === StandardBasisVector(Float64, 5, 2)
+    end
+
     @testset "Dimensions" begin
         @test axes(StandardBasisVector(10, 3)) == (1:10,)
         @test axes(StandardBasisVector(10, 3), 1) == 1:10
@@ -51,7 +56,7 @@
             @eval @test first(StandardBasisVector($T, 6, 1)) == 1
             @eval @test last(StandardBasisVector($T, 6, 3)) == 0
             @eval @test last(StandardBasisVector($T, 6, 6)) == 1
-            @eval @test StandardBasisVector($T, 6, 5)[:] == [0,0,0,0,1,0]
+            @eval @test StandardBasisVector($T, 6, 5)[:] === StandardBasisVector($T, 6, 5)
             @eval @test StandardBasisVector($T, 6, 5)[1] == 0
             @eval @test StandardBasisVector($T, 6, 5)[5] == 1
             @eval @test StandardBasisVector($T, 6, 5)[end] == 0


### PR DESCRIPTION
… and also use them for indexing with `Colon()`, i.e., `x[:]`.