### PR TITLE
Make `bsplines!` return `OffsetArray`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## master
 
-* ![BREAKING](https://img.shields.io/badge/-BREAKING-red) `bsplines!(dest, args...)` now returns an `OffsetArray` that wraps `dest`, making its output equal to that of `bsplines(args...)`.
+* ![BREAKING](https://img.shields.io/badge/-BREAKING-red) `bsplines!(dest, args...)` now returns an `OffsetArray` that wraps `dest`, making its output equal to that of `bsplines(args...)`. ([#8](https://github.com/sostock/BSplines.jl/pull/8))
 
 ## v0.2.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # BSplines.jl changelog
 
+## master
+
+* ![BREAKING](https://img.shields.io/badge/-BREAKING-red) `bsplines!(dest, args...)` now returns an `OffsetArray` that wraps `dest`, making its output equal to that of `bsplines(args...)`.
+
 ## v0.2.5
 
 * ![Enhancement](https://img.shields.io/badge/-enhancement-blue) `length(::BSplineBasis)` now always returns a value of type `Int`. ([#7](https://github.com/sostock/BSplines.jl/pull/7))

--- a/docs/src/basis.md
+++ b/docs/src/basis.md
@@ -88,27 +88,23 @@ bsplines(basis, 4, AllDerivatives(3)) # calculate zeroth, first and second deriv
 ### Pre-allocating output arrays
 
 The `bsplines` function allocates a new array to return the values (except when it returns `nothing`).
-In order to write the values to a pre-allocated array instead, the [`bsplines!`](@ref) function can be used.
-
-The `bsplines!` function returns an integer `offset` such that the `i`-th element of the destination array contains the value (or derivative) of the `i+offset`-th B-spline.
-In the case of `AllDerivatives{N}`, the destination array contains the `j-1`-th derivative of the `i+offset`-th B-spline at the index `i, j`.
-If the point `x` is outside of the support of the basis, `nothing` is returned instead and the destination array is not mutated.
+In order to use a pre-allocated array instead, the [`bsplines!`](@ref) function can be used: `bsplines!(dest, args...)` behaves like `bsplines(args...)`, but the calculations are done in `dest` and the returned `OffsetArray` is a wrapper around `dest`.
 
 ```@repl basis
 basis = BSplineBasis(4, 0:5);
-vec = zeros(4);
-bsplines!(vec, basis, 3.2)
-vec
-bsplines!(vec, basis, 7//3, Derivative(2))
-vec
-mat = zeros(Rational{Int}, 4, 2);
-bsplines!(mat, basis, 4, AllDerivatives(2))
-mat
+destvec = zeros(4);
+bsplines!(destvec, basis, 3.2)
+parent(ans) === destvec
+bsplines!(destvec, basis, 7//3, Derivative(2))
+parent(ans) === destvec
+destmat = zeros(Rational{Int}, 4, 2);
+bsplines!(destmat, basis, 4, AllDerivatives(2))
+parent(ans) === destmat
 ```
 
-When calculating values of B-splines or their derivatives via the `Derivative{N}` argument, the destination must be a vector of length `order(basis)`.
-In the case of the `AllDerivatives{N}` argument, the destination must be a matrix of size `(order(basis), N)`.
-In any case, the destination array must not have offset axes.
+When calculating values of B-splines or their derivatives via the `Derivative{N}` argument, `dest` must be a vector of length `order(basis)`.
+In the case of the `AllDerivatives{N}` argument, it must be a matrix of size `(order(basis), N)`.
+In any case, `dest` must not have offset axes itself.
 
 ### Specifying the relevant interval
 

--- a/src/bsplinebasis.jl
+++ b/src/bsplinebasis.jl
@@ -448,7 +448,7 @@ bsplines(basis, x; kwargs...)
 """
     bsplines(basis, x, ::Derivative{N}; leftknot=intervalindex(basis, x))
 
-Calculate the `N`-th derivatives of all B-splines of `basis` that are non-zero at `x`.
+Calculate the `N`-th derivatives of all non-zero B-splines of `basis` at `x`.
 
 If any B-splines are non-zero at `x`, an `OffsetVector` is returned that contains the `N`-th
 derivative of the `i`-th B-spline at the index `i`. If no B-splines are non-zero at `x`,
@@ -481,8 +481,7 @@ bsplines(basis, x, ::Derivative; kwargs...)
 """
     bsplines(basis, x, ::AllDerivatives{N}; leftknot=intervalindex(basis, x))
 
-Calculate all `m`-th derivatives (`0 ≤ m < N`) of all B-splines of `basis` that are non-zero
-at `x`.
+Calculate all `m`-th derivatives (`0 ≤ m < N`) of all non-zero B-splines of `basis` at `x`.
 
 If any B-splines are non-zero at `x`, an `OffsetMatrix` is returned that contains the `m`-th
 derivative of the `i`-th B-spline at the index `i, m`. If no B-splines are non-zero at `x`,
@@ -513,14 +512,14 @@ julia> bsplines(BSplineBasis(4, 0:5), 17//5, AllDerivatives(4), leftknot=7)
 bsplines(basis, x, ::AllDerivatives; kwargs...)
 
 """
-    bsplines!(dest, basis, x; leftknot=intervalindex(basis, x)) -> offset
+    bsplines!(dest, basis, x; leftknot=intervalindex(basis, x))
 
-Calculate the values of all B-splines of `basis` that are non-zero at `x` and store the
-result in `dest`. The destination vector `dest` must have the length `order(basis)`.
+Calculate the values of all non-zero B-splines of `basis` at `x` in-place (i.e., in `dest`).
+The destination vector `dest` must have the length `order(basis)`.
 
-If any B-splines are non-zero at `x`, an integer `offset` is returned and the value of the
-`i`-th B-spline is written to `dest[i-offset]`. If no B-splines are non-zero at `x`,
-`nothing` is returned and `dest` is not mutated.
+If any B-splines are non-zero at `x`, an `OffsetVector` is returned that wraps `dest` and
+contains the value of the `i`-th B-spline at the index `i`. If no B-splines are non-zero at
+`x`, `nothing` is returned and `dest` is not mutated.
 
 If the index of the relevant interval is already known, it can be supplied with the optional
 `leftknot` keyword to speed up the calculation.
@@ -531,14 +530,14 @@ If the index of the relevant interval is already known, it can be supplied with 
 julia> dest = zeros(4);
 
 julia> bsplines!(dest, BSplineBasis(4, 0:5), 2.4)
-2
-
-julia> dest # dest[i] contains value of (i+2)-th B-spline
-4-element Array{Float64,1}:
+4-element OffsetArray(::Array{Float64,1}, 3:6) with eltype Float64 with indices 3:6:
  0.03600000000000002
- 0.5386666666666667 
+ 0.5386666666666667
  0.41466666666666663
  0.01066666666666666
+
+julia> parent(ans) === dest
+true
 ```
 """
 bsplines!(dest, basis, x; kwargs...)
@@ -546,11 +545,11 @@ bsplines!(dest, basis, x; kwargs...)
 """
     bsplines!(dest, basis, x, ::Derivative{N}; leftknot=intervalindex(basis, x))
 
-Calculate the values of all B-splines of `basis` that are non-zero at `x` and store the
-result in `dest`. The destination vector `dest` must have the length `order(basis)`.
+Calculate the `N`-th derivatives of all non-zero B-splines of `basis` at `x` in-place (i.e.,
+in `dest`). The destination vector `dest` must have the length `order(basis)`.
 
-If any B-splines are non-zero at `x`, an integer `offset` is returned and the `N`-th
-derivative of the `i`-th B-spline is written to `dest[i-offset]`. If no B-splines are
+If any B-splines are non-zero at `x`, an `OffsetVector` is returned that wraps `dest` and
+contains the `N`-th derivative of the `i`-th B-spline at the index `i`. If no B-splines are
 non-zero at `x`, `nothing` is returned and `dest` is not mutated.
 
 If the index of the relevant interval is already known, it can be supplied with the optional
@@ -564,14 +563,14 @@ julia> dest = zeros(4);
 julia> bsplines!(dest, BSplineBasis(4, 0:5), 7.0, Derivative(2)) # returns nothing
 
 julia> bsplines!(dest, BSplineBasis(4, 0:5), 4.2, Derivative(2))
-4
-
-julia> dest # dest[i] contains 2nd derivative of (i+4)-th B-spline
-4-element Array{Float64,1}:
+4-element OffsetArray(::Array{Float64,1}, 5:8) with eltype Float64 with indices 5:8:
   0.7999999999999998
- -1.399999999999999 
+ -1.399999999999999
  -0.6000000000000019
-  1.200000000000001 
+  1.200000000000001
+
+julia> parent(ans) === dest
+true
 ```
 """
 bsplines!(dest, basis, x, ::Derivative; kwargs...)
@@ -579,12 +578,13 @@ bsplines!(dest, basis, x, ::Derivative; kwargs...)
 """
     bsplines!(dest, basis, x, ::AllDerivatives{N}; leftknot=intervalindex(basis, x))
 
-Calculate the values of all B-splines of `basis` that are non-zero at `x` and store the
-result in `dest`. The destination matrix `dest` must have the dimensions `order(basis)`×`N`.
+Calculate all `m`-th derivatives (`0 ≤ m < N`) of all non-zero B-splines of `basis` at `x`
+in-place (i.e., in `dest`). The destination matrix `dest` must have the size
+`(order(basis), N)`.
 
-If any B-splines are non-zero at `x`, an integer `offset` is returned and the `m`-th
-derivative of the `i`-th B-spline is written to `dest[i-offset, m+1]`. If no B-splines are
-non-zero at `x`, `nothing` is returned and `dest` is not mutated.
+If any B-splines are non-zero at `x`, an `OffsetArray` is returned that wraps `dest` and
+contains the `m`-th derivative of the `i`-th B-spline at the index `i, m`. If no B-splines
+are non-zero at `x`, `nothing` is returned and `dest` is not mutated.
 
 If the index of the relevant interval is already known, it can be supplied with the optional
 `leftknot` keyword to speed up the calculation.
@@ -597,14 +597,14 @@ julia> dest = zeros(4, 3);
 julia> bsplines!(dest, BSplineBasis(4, 0:5), -1.0, AllDerivatives(3)) # returns nothing
 
 julia> bsplines!(dest, BSplineBasis(4, 0:5), 3.75, AllDerivatives(3))
-3
-
-julia> dest # dest[i,m] contains (m-1)-th derivative of (i+3)-th B-spline
-4×3 Array{Float64,2}:
- 0.00260417  -0.03125    0.25 
- 0.315104    -0.65625    0.25 
+4×3 OffsetArray(::Array{Float64,2}, 4:7, 0:2) with eltype Float64 with indices 4:7×0:2:
+ 0.00260417  -0.03125    0.25
+ 0.315104    -0.65625    0.25
  0.576823     0.265625  -1.625
  0.105469     0.421875   1.125
+
+julia> parent(ans) === dest
+true
 ```
 """
 bsplines!(dest, basis, x, ::AllDerivatives; kwargs...)
@@ -624,7 +624,8 @@ function bsplines!(dest, basis::BSplineBasis, x, drv=NoDerivative(); leftknot=in
     check_intervalindex(basis, x, leftknot)
     leftknot === nothing && return nothing
     check_destarray_axes(dest, basis, drv)
-    @inbounds _bsplines!(dest, basis, x, leftknot, drv)
+    offset = @inbounds _bsplines!(dest, basis, x, leftknot, drv)
+    bsplines_offsetarray(dest, offset, drv)
 end
 
 bsplines_destarray(basis, x, ::Derivative) =
@@ -835,10 +836,9 @@ function _basismatrix!(dest, workspace, basis::BSplineBasis, xvalues, indices::A
         leftknot = intervalindex(basis, x, start)
         @assert leftknot !== nothing "xvalue outside of the support of basis: $x."
         start = leftknot
-        boffset = bsplines!(workspace, basis, x, leftknot=leftknot)
-        bindices = boffset .+ axes(workspace, 1)
-        for bindex = bindices ∩ indices
-            dest[xindex, bindex-indicesoffset] = workspace[bindex-boffset]
+        bspl = bsplines!(workspace, basis, x, leftknot=leftknot)
+        for index = axes(bspl, 1) ∩ indices
+            dest[xindex, index-indicesoffset] = bspl[index]
         end
     end
 end
@@ -849,9 +849,9 @@ function _basismatrix!(dest, workspace, basis::BSplineBasis, xvalues, ::Colon)
         leftknot = intervalindex(basis, x, start)
         @assert leftknot !== nothing "xvalue outside of the support of basis: $x."
         start = leftknot
-        boffset = bsplines!(workspace, basis, x, leftknot=leftknot)
-        for index = axes(workspace, 1)
-            dest[xindex, index+boffset] = workspace[index]
+        bspl = bsplines!(workspace, basis, x, leftknot=leftknot)
+        for index = axes(bspl, 1)
+            dest[xindex, index] = bspl[index]
         end
     end
 end


### PR DESCRIPTION
This makes the output of `bsplines!(dest, args...)` equivalent to that of `bsplines(args...)`. The returned `OffsetArray` is a wrapper around `dest`.