### PR TITLE
Add `workspace` keyword argument to `splinevalue`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## master
 
 * ![BREAKING](https://img.shields.io/badge/-BREAKING-red) `bsplines!(dest, args...)` now returns an `OffsetArray` that wraps `dest`, making its output equal to that of `bsplines(args...)`. ([#8](https://github.com/sostock/BSplines.jl/pull/8))
+
+* ![Feature](https://img.shields.io/badge/-feature-green) `splinevalue` now has an optional `workspace` keyword argument for providing a vector to store intermediate values in order to avoid unnecessary allocations. ([#10](https://github.com/sostock/BSplines.jl/pull/10))
+
 * ![Enhancement](https://img.shields.io/badge/-enhancement-blue) The default printing of `BSplineBasis` and `Spline` now uses the compact style for printing the breakpoint and coefficient vectors. ([#9](https://github.com/sostock/BSplines.jl/pull/9))
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * ![BREAKING](https://img.shields.io/badge/-BREAKING-red) `bsplines!(dest, args...)` now returns an `OffsetArray` that wraps `dest`, making its output equal to that of `bsplines(args...)`. ([#8](https://github.com/sostock/BSplines.jl/pull/8))
 
-* ![Feature](https://img.shields.io/badge/-feature-green) `splinevalue` now has an optional `workspace` keyword argument for providing a vector to store intermediate values in order to avoid unnecessary allocations. ([#10](https://github.com/sostock/BSplines.jl/pull/10))
+* ![Feature](https://img.shields.io/badge/-feature-green) `splinevalue` now accepts a keyword argument `workspace` for providing a vector to store intermediate values in order to avoid unnecessary allocations. ([#10](https://github.com/sostock/BSplines.jl/pull/10))
 
 * ![Enhancement](https://img.shields.io/badge/-enhancement-blue) The default printing of `BSplineBasis` and `Spline` now uses the compact style for printing the breakpoint and coefficient vectors. ([#9](https://github.com/sostock/BSplines.jl/pull/9))
 

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,4 +1,5 @@
 [deps]
+BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 

--- a/docs/src/spline.md
+++ b/docs/src/spline.md
@@ -39,9 +39,6 @@ splinevalue(spl, 2.5, Derivative(2))
 !!! info
     The [`AllDerivatives{N}`](@ref) type is not supported as an argument.
 
-Evaluating a spline at a point `x` requires finding the largest index `i` such that `t[i] ≤ x` and `t[i] < t[end]` where `t` is the knot vector of the basis.
-If the index is already known, it can be specified with the `leftknot` keyword argument to speed up the computation.
-
 ## Arithmetic with `Spline`s
 
 A `Spline` can be multiplied or divided by a real number using `*`, `/`, or `\`.
@@ -95,4 +92,26 @@ bspl = b[3]
 spl == bspl
 support(spl) # support of the basis
 support(bspl) # actual support of the B-spline
+```
+
+## Performance considerations
+
+Two optional keyword arguments can be used to speed up the evaluation of splines:
+
+  * Evaluating a spline at a point `x` requires finding the largest index `i` such that `t[i] ≤ x` and `t[i] < t[end]` where `t` is the knot vector of the basis.
+    If the index is already known, it can be specified with the `leftknot` keyword argument.
+  * To evaluate a spline, a vector of length `order(spline)` is used to store intermediate values.
+    By default, a new vector is allocated for each evaluation.
+    To avoid this, a pre-allocated vector can be specified with the `workspace` keyword argument.
+    Note that in this case, the calculations are performed with numbers of type `eltype(workspace)`.
+
+```@repl spline
+using BenchmarkTools
+spl = Spline(BSplineBasis(4, 0:5), rand(8));
+left = intervalindex(basis(spl), 2.5);
+work = zeros(order(spl));
+@btime $spl(2.5)
+@btime $spl(2.5, leftknot=$left)
+@btime $spl(2.5, workspace=$work)
+@btime $spl(2.5, leftknot=$left, workspace=$work)
 ```

--- a/test/bsplines.jl
+++ b/test/bsplines.jl
@@ -16,9 +16,10 @@ function bsplines_exact(funs, x, indices, ::AllDerivatives{N}) where N
 end
 
 # Enlarge x for calculating exact B-splines:
-# * for Integer/Rational: use at least 64-bit to avoid overflow in rational arithmetic
+# * for Integer/Rational: use 64-bit to avoid overflow in rational arithmetic
 # * for floating-point: use BigFloat to minimize error
-maybebig(x::Union{Integer,Rational}) = x*one(Int64)
+maybebig(x::Integer) = Int64(x)
+maybebig(x::Rational) = Rational{Int64}(x)
 maybebig(x::AbstractFloat) = big(x)
 
 @time @testset "bsplines" begin

--- a/test/splinevalue.jl
+++ b/test/splinevalue.jl
@@ -1,109 +1,106 @@
 @time @testset "splinevalue" begin
+
+    # b1 = BSplineBasis(1, 0:5)
+    s1 = Spline(b1, 1.0:5.0)
+    # b2 = BSplineBasis(2, big(0):1:big(5))
+    s2 = Spline(b2, 6.0:-1:1.0)
+    # b3 = BSplineBasis(3, 0//1:5//1)
+    s3 = Spline(b3, -30:10:30)
+    # b4 = BSplineBasis(4, Int128[0,1,2,3,4,5])
+    s4 = Spline(b4, 1:8)
+    # b5 = BSplineBasis(3, [-5.0, -3.5, -2.2, 1.0, 2.0, 3.6])
+    s5 = Spline(b5, ones(Float64, 7))
+    # b6 = BSplineBasis(4, Rational{Int64}[-5//1, -7//2, -11//5, 1//1, 2//1, 18//5])
+    s6 = Spline(b6, [1//i for i=eachindex(b6)])
+    # b7 = BSplineBasis(3, Int8[-6,-4,-2,0,0,1,2])
+    s7 = Spline(b7, view(1:10, 2:9))
+
     @testset "Return types" begin
-        function test_splinevalue_returntype(spline, xtype, bspline_type)
-            leftknot = intervalindex(basis(spline), 1)
+        function test_splinevalue_returntype(spline, xtype, bspline_type, leftknot=intervalindex(basis(spline), 1))
             x = one(xtype)
-            @test @inferred(splinevalue(spline, x)) isa bspline_type
-            @test @inferred(splinevalue(spline, x, Derivative(2))) isa bspline_type
+            @test @inferred(splinevalue(spline, x, leftknot=leftknot)) isa bspline_type
+            @test @inferred(splinevalue(spline, x, Derivative(1), leftknot=leftknot)) isa bspline_type
+        end
+        function test_splinevalue_returntype_workspace(spline, leftknot=intervalindex(basis(spline), 1))
+            for (T,N) = ((Float32,0), (Float64,1), (BigFloat,2), (Rational{Int64},3), (Rational{BigInt},4))
+                work = Vector{T}(undef, order(spline))
+                @test @inferred(splinevalue(spline, 1, Derivative(N), leftknot=leftknot, workspace=work)) isa T
+            end
         end
 
         # b1 = BSplineBasis(1, 0:5)
-        b1_bspline_types = [(Int,Float64), (Float64,Float64), (Float32,Float32),
-                            (Rational{Int},Rational{Int}), (BigInt,BigFloat),
-                            (BigFloat,BigFloat), (Rational{BigInt},Rational{BigInt})]
+        b1_bspline_types = [(Int,Float64), (BigInt,BigFloat),
+                            (Float32,Float32), (Float64,Float64), (BigFloat,BigFloat),
+                            (Rational{Int},Rational{Int}), (Rational{BigInt},Rational{BigInt})]
         # b2 = BSplineBasis(2, big(0):1:big(5))
-        b2_bspline_types = [(Int,BigFloat), (Float64,BigFloat), (Float32,BigFloat),
-                            (Rational{Int},Rational{BigInt}), (BigInt,BigFloat),
-                            (BigFloat,BigFloat), (Rational{BigInt},Rational{BigInt})]
+        b2_bspline_types = [(Int,BigFloat), (Float32,BigFloat), (Rational{Int},Rational{BigInt})]
         # b3 = BSplineBasis(3, 0//1:5//1)
-        b3_bspline_types = [(Int,Rational{Int}), (Float64,Float64), (Float32,Float32),
-                            (Rational{Int},Rational{Int}), (BigInt,Rational{BigInt}),
-                            (BigFloat,BigFloat), (Rational{BigInt},Rational{BigInt})]
+        b3_bspline_types = [(BigInt,Rational{BigInt}), (Float64,Float64), (Rational{BigInt},Rational{BigInt})]
         # b4 = BSplineBasis(4, Int128[0,1,2,3,4,5])
-        b4_bspline_types = [(Int,Float64), (Float64,Float64), (Float32,Float32),
-                            (Rational{Int},Rational{Int128}), (BigInt,BigFloat),
-                            (BigFloat,BigFloat), (Rational{BigInt},Rational{BigInt})]
+        b4_bspline_types = [(Int,Float64), (BigFloat,BigFloat), (Rational{Int},Rational{Int128})]
         # b5 = BSplineBasis(3, [-5.0, -3.5, -2.2, 1.0, 2.0, 3.6])
-        b5_bspline_types = [(Int,Float64), (Float64,Float64), (Float32,Float64),
-                            (Rational{Int},Float64), (BigInt,BigFloat),
-                            (BigFloat,BigFloat), (Rational{BigInt},BigFloat)]
+        b5_bspline_types = [(BigInt,BigFloat), (Float32,Float64), (Rational{BigInt},BigFloat)]
         # b6 = BSplineBasis(4, Rational{Int64}[-5//1, -7//2, -11//5, 1//1, 2//1, 18//5])
-        b6_bspline_types = [(Int,Rational{Int64}), (Float64,Float64), (Float32,Float32),
-                            (Rational{Int},Rational{Int64}), (BigInt,Rational{BigInt}),
-                            (BigFloat,BigFloat), (Rational{BigInt},Rational{BigInt})]
+        b6_bspline_types = [(Int,Rational{Int64}), (Float64,Float64), (Rational{Int},Rational{Int64})]
         # b7 = BSplineBasis(3, Int8[-6,-4,-2,0,0,1,2])
-        b7_bspline_types = [(Int,Float64), (Float64,Float64), (Float32,Float32),
-                            (Rational{Int},Rational{Int}), (BigInt,BigFloat),
-                            (BigFloat,BigFloat), (Rational{BigInt},Rational{BigInt})]
+        b7_bspline_types = [(BigInt,BigFloat), (BigFloat,BigFloat), (Rational{Int},Rational{Int})]
         for (basis, types) = [(b1, b1_bspline_types), (b2, b2_bspline_types),
                               (b3, b3_bspline_types), (b4, b4_bspline_types),
                               (b5, b5_bspline_types), (b6, b6_bspline_types),
                               (b7, b7_bspline_types)]
             bspline = basis[1]
+            leftknot = intervalindex(basis, 1)
+            test_splinevalue_returntype_workspace(bspline, leftknot)
             for (xtype, bspline_type) in types
-                test_splinevalue_returntype(bspline, xtype, bspline_type)
+                test_splinevalue_returntype(bspline, xtype, bspline_type, leftknot)
             end
         end
 
         # b1 = BSplineBasis(1, 0:5)
-        b1_coeffs_and_types = [(Float32.(1:5),Int,Float32), (1:5,Int,Float64),
-                               (1:5,BigInt,BigFloat), (Float64.(1:5),Int,Float64),
-                               (1:5,Float32,Float32), (1:5,Rational{Int},Rational{Int}),
-                               (1//2:9//2,BigInt,Rational{BigInt}),
-                               (1//2:9//2,Float64,Float64),
-                               (Float16.(1:5),BigFloat,BigFloat),
-                               (big(1//2):big(9//2),Float64,BigFloat)]
+        b1_coeffs_and_types = [(1:5,Int,Float64),
+                               (1:5,Float32,Float32)]
         # b2 = BSplineBasis(2, big(0):1:big(5))
-        b2_coeffs_and_types = [(Float64.(1:6),Int,BigFloat),
-                               (Float32.(1:6),Float32,BigFloat),
-                               (1//1:6//1,Float64,BigFloat),
-                               (1//1:6//1,Int8,Rational{BigInt}), (1:6,Int,BigFloat),
-                               (1:6,Rational{Int},Rational{BigInt}), (1:6,Int,BigFloat)]
+        b2_coeffs_and_types = [(1//1:6//1,Int8,Rational{BigInt}),
+                               (1:6,Int,BigFloat)]
         # b3 = BSplineBasis(3, 0//1:5//1)
-        b3_coeffs_and_types = [(1:7,Int,Rational{Int}), (1:7,Float32,Float32),
-                               (1:7,Float64,Float64), (Float32.(1:7),Rational{Int},Float32),
-                               (Float64.(1:7),BigFloat,BigFloat),
-                               (1:7,BigInt,Rational{BigInt}),
-                               (Float32.(1:7),Float64,Float64),
-                               (Float64.(1:7),Float32,Float64),
-                               (BigFloat.(1:7),Rational{Int},BigFloat)]
+        b3_coeffs_and_types = [(1:7,Float32,Float32),
+                               (Float32.(1:7),Float64,Float64)]
         # b4 = BSplineBasis(4, Int128[0,1,2,3,4,5])
-        b4_coeffs_and_types = [(Float32.(1:8),Int,Float32),
-                               (Float64.(1:8),Rational{Int},Float64),
-                               (BigFloat.(1:8),Int,BigFloat),
-                               (BigFloat.(1:8),Float64,BigFloat),
-                               (1:8,Rational{Int},Rational{Int128}), (1:8,BigInt,BigFloat)]
+        b4_coeffs_and_types = [(Float64.(1:8),Rational{Int},Float64),
+                               (1:8,Rational{Int},Rational{Int128})]
         # b5 = BSplineBasis(3, [-5.0, -3.5, -2.2, 1.0, 2.0, 3.6])
-        b5_coeffs_and_types = [(1:7,Int,Float64), (Float32.(1:7),Float32,Float64),
-                               (1//1:7//1,BigInt,BigFloat),
-                               (Float64.(1:7),BigFloat,BigFloat),
+        b5_coeffs_and_types = [(Float32.(1:7),Float32,Float64),
                                (big(1):big(7),Float64,BigFloat)]
         # b6 = BSplineBasis(4, Rational{Int64}[-5//1, -7//2, -11//5, 1//1, 2//1, 18//5])
-        b6_coeffs_and_types = [(1:8,Int,Rational{Int64}), (Float32.(1:8),Float32,Float32),
-                               (1:8,Float64,Float64), (1//1:8//1,Int,Rational{Int64}),
-                               (Float64.(1:8),Float64,Float64)]
+        b6_coeffs_and_types = [(1:8,Int,Rational{Int64}),
+                               (1:8,Float64,Float64)]
         # b7 = BSplineBasis(3, Int8[-6,-4,-2,0,0,1,2])
-        b7_coeffs_and_types = [(Float32.(1:8),Int,Float32),
-                               (Float64.(1:8),Rational{Int},Float64),
-                               (BigFloat.(1:8),Int,BigFloat),
-                               (BigFloat.(1:8),Float64,BigFloat),
-                               (1:8,Rational{Int},Rational{Int}), (1:8,BigInt,BigFloat)]
+        b7_coeffs_and_types = [(Float64.(1:8),Rational{Int},Float64),
+                               (BigFloat.(1:8),Int,BigFloat)]
         for (basis, coeffs_and_types) = [(b1, b1_coeffs_and_types), (b2, b2_coeffs_and_types),
                                          (b3, b3_coeffs_and_types), (b4, b4_coeffs_and_types),
                                          (b5, b5_coeffs_and_types), (b6, b6_coeffs_and_types),
                                          (b7, b7_coeffs_and_types)]
+            leftknot = intervalindex(basis, 1)
             for (coeffs, xtype, bspline_type) in coeffs_and_types
                 spline = Spline(basis, coeffs)
-                test_splinevalue_returntype(spline, xtype, bspline_type)
+                test_splinevalue_returntype(spline, xtype, bspline_type, leftknot)
             end
+        end
+        for spline = [s1, s2, s3, s4, s5, s6, s7]
+            test_splinevalue_returntype_workspace(spline)
         end
     end
 
     function test_splinevalue_zero(spline::Spline, x)
+        work = zeros(order(spline))
         for N = 0:3
             @test splinevalue(spline, x, Derivative(N)) == 0
+            @test splinevalue(spline, x, Derivative(N), workspace=work) == 0
             @test splinevalue(spline, x, Derivative(N), leftknot=nothing) == 0
+            @test splinevalue(spline, x, Derivative(N), leftknot=nothing, workspace=work) == 0
             @test_throws ArgumentError splinevalue(spline, x, Derivative(N), leftknot=1)
+            @test_throws ArgumentError splinevalue(spline, x, Derivative(N), leftknot=1, workspace=work)
         end
     end
     test_splinevalue_zero(b1[1], Inf16)
@@ -115,13 +112,17 @@
     test_splinevalue_zero(b7[7], 100)
 
     function test_splinevalue_nan(spline::Spline, x)
+        work = zeros(order(spline))
         for N = 0:3
             @test isnan(splinevalue(spline, x, Derivative(N)))
+            @test isnan(splinevalue(spline, x, Derivative(N), workspace=work))
         end
         if isnan(x)
             for N = 0:3
                 @test isnan(splinevalue(spline, x, Derivative(N), leftknot=nothing))
+                @test isnan(splinevalue(spline, x, Derivative(N), leftknot=nothing, workspace=work))
                 @test_throws ArgumentError splinevalue(spline, x, Derivative(N), leftknot=1)
+                @test_throws ArgumentError splinevalue(spline, x, Derivative(N), leftknot=1, workspace=work)
             end
         end
     end
@@ -141,21 +142,25 @@
         end
     end
     # Enlarge x for calculating exact B-splines:
-    # * for Integer/Rational: use at least 64-bit to avoid overflow in rational arithmetic
+    # * for Integer/Rational: use 64-bit to avoid overflow in rational arithmetic
     # * for floating-point: use BigFloat to minimize error
-    maybebig(x::Union{Integer,Rational}) = x*one(Int64)
+    maybebig(x::Integer) = Int64(x)
+    maybebig(x::Rational) = Rational{Int64}(x)
     maybebig(x::AbstractFloat) = big(x)
 
-    function test_splinevalue_nonzero(bspline::Spline, basis_exact, x, isexact)
-        leftknot = intervalindex(basis(bspline), x)
+    function test_splinevalue_nonzero(spline::Spline, basis_exact, x, isexact)
+        leftknot = intervalindex(basis(spline), x)
         leftknot === nothing && error("this function is only suitable for x which are inside the support of the basis")
+        work = Array{isexact ? Rational{Int64} : Float64}(undef, order(spline))
         for N = 0:3
-            spl = splinevalue(bspline, x, Derivative(N), leftknot=leftknot)
-            exact = splinevalue_exact(basis_exact, coeffs(bspline), x, N)
+            spl = splinevalue(spline, x, Derivative(N), leftknot=leftknot)
+            exact = splinevalue_exact(basis_exact, coeffs(spline), x, N)
             if isexact
-                @test spl == exact
+                @test splinevalue(spline, x, Derivative(N), leftknot=leftknot) == exact
+                @test splinevalue(spline, x, Derivative(N), leftknot=leftknot, workspace=work) == exact
             else
-                @test spl ≈ₑₗ exact
+                @test splinevalue(spline, x, Derivative(N), leftknot=leftknot) ≈ₑₗ exact
+                @test splinevalue(spline, x, Derivative(N), leftknot=leftknot, workspace=work) ≈ₑₗ exact
             end
         end
     end
@@ -189,40 +194,26 @@
     end
 
     # b1 = BSplineBasis(1, 0:5)
-    test_splinevalue_bsplines(b1, b1_exact, Int,              true)
     test_splinevalue_bsplines(b1, b1_exact, BigInt,           true)
     test_splinevalue_bsplines(b1, b1_exact, Float32,          true)
-    test_splinevalue_bsplines(b1, b1_exact, Rational{Int},    true)
     # b2 = BSplineBasis(2, big(0):1:big(5))
-    test_splinevalue_bsplines(b2, b2_exact, BigInt,           false)
     test_splinevalue_bsplines(b2, b2_exact, BigFloat,         false)
-    test_splinevalue_bsplines(b2, b2_exact, Rational{Int},    true)
-    test_splinevalue_bsplines(b2, b2_exact, Rational{BigInt}, true)
+    test_splinevalue_bsplines(b2, b2_exact, Rational{Int32},  true)
     # b3 = BSplineBasis(3, 0//1:5//1)
-    test_splinevalue_bsplines(b3, b3_exact, Int,              true)
-    test_splinevalue_bsplines(b3, b3_exact, Float32,          false)
     test_splinevalue_bsplines(b3, b3_exact, Float64,          false)
     test_splinevalue_bsplines(b3, b3_exact, Rational{BigInt}, true)
     # b4 = BSplineBasis(4, Int128[0,1,2,3,4,5])
     test_splinevalue_bsplines(b4, b4_exact, BigInt,           false)
-    test_splinevalue_bsplines(b4, b4_exact, Float64,          false)
-    test_splinevalue_bsplines(b4, b4_exact, Rational{Int},    true)
-    test_splinevalue_bsplines(b4, b4_exact, Rational{BigInt}, true)
+    test_splinevalue_bsplines(b4, b4_exact, Rational{Int64},  true)
     # b5 = BSplineBasis(3, [-5.0, -3.5, -2.2, 1.0, 2.0, 3.6])
     test_splinevalue_bsplines(b5, b5_exact, Int,              false)
     test_splinevalue_bsplines(b5, b5_exact, Float32,          false)
-    test_splinevalue_bsplines(b5, b5_exact, Float64,          false)
-    test_splinevalue_bsplines(b5, b5_exact, BigFloat,         false)
     # b6 = BSplineBasis(4, Rational{Int64}[-5//1, -7//2, -11//5, 1//1, 2//1, 18//5])
     test_splinevalue_bsplines(b6, b6_exact, Int,              true)
     test_splinevalue_bsplines(b6, b6_exact, Float64,          false)
-    test_splinevalue_bsplines(b6, b6_exact, BigFloat,         false)
-    test_splinevalue_bsplines(b6, b6_exact, Rational{Int},    true)
     # b7 = BSplineBasis(3, Int8[-6,-4,-2,0,0,1,2])
-    test_splinevalue_bsplines(b4, b4_exact, Int32,            false)
-    test_splinevalue_bsplines(b4, b4_exact, BigFloat,         false)
-    test_splinevalue_bsplines(b4, b4_exact, Rational{Int16},  true)
-    test_splinevalue_bsplines(b4, b4_exact, Rational{Int128}, true)
+    test_splinevalue_bsplines(b7, b7_exact, BigFloat,         false)
+    test_splinevalue_bsplines(b7, b7_exact, Rational{Int16},  true)
 
     function test_splinevalue(spline::Spline, basis_exact, xtype, isexact)
         a, b = support(spline)
@@ -232,47 +223,33 @@
     end
 
     # b1 = BSplineBasis(1, 0:5)
-    s1 = Spline(b1, 1.0:5.0)
-    test_splinevalue(s1, b1_exact, Int,              true)
+    # s1 = Spline(b1, 1.0:5.0)
     test_splinevalue(s1, b1_exact, BigInt,           true)
     test_splinevalue(s1, b1_exact, Float64,          true)
-    test_splinevalue(s1, b1_exact, Rational{BigInt}, true)
     # b2 = BSplineBasis(2, big(0):1:big(5))
-    s2 = Spline(b2, 6.0:-1:1.0)
-    test_splinevalue(s2, b2_exact, BigInt,           false)
-    test_splinevalue(s2, b2_exact, Float32,          false)
+    # s2 = Spline(b2, 6.0:-1:1.0)
     test_splinevalue(s2, b2_exact, BigFloat,         false)
-    test_splinevalue(s2, b2_exact, Rational{Int},    false)
+    test_splinevalue(s2, b2_exact, Rational{Int32},  false)
     # b3 = BSplineBasis(3, 0//1:5//1)
-    s3 = Spline(b3, -30:10:30)
-    test_splinevalue(s3, b3_exact, Int,              true)
+    # s3 = Spline(b3, -30:10:30)
     test_splinevalue(s3, b3_exact, Float32,          false)
-    test_splinevalue(s3, b3_exact, BigFloat,         false)
     test_splinevalue(s3, b3_exact, Rational{BigInt}, true)
     # b4 = BSplineBasis(4, Int128[0,1,2,3,4,5])
-    s4 = Spline(b4, 1:8)
+    # s4 = Spline(b4, 1:8)
     test_splinevalue(s4, b4_exact, BigInt,           false)
-    test_splinevalue(s4, b4_exact, Float64,          false)
-    test_splinevalue(s4, b4_exact, Rational{Int},    true)
-    test_splinevalue(s4, b4_exact, Rational{BigInt}, true)
+    test_splinevalue(s4, b4_exact, Rational{Int64},  true)
     # b5 = BSplineBasis(3, [-5.0, -3.5, -2.2, 1.0, 2.0, 3.6])
-    s5 = Spline(b5, ones(Float64, 7))
+    # s5 = Spline(b5, ones(Float64, 7))
     test_splinevalue(s5, b5_exact, Int,              false)
     test_splinevalue(s5, b5_exact, Float32,          false)
-    test_splinevalue(s5, b5_exact, Float64,          false)
-    test_splinevalue(s5, b5_exact, BigFloat,         false)
     # b6 = BSplineBasis(4, Rational{Int64}[-5//1, -7//2, -11//5, 1//1, 2//1, 18//5])
-    s6 = Spline(b6, [1//i for i=eachindex(b6)])
+    # s6 = Spline(b6, [1//i for i=eachindex(b6)])
     test_splinevalue(s6, b6_exact, Int,              true)
-    test_splinevalue(s6, b6_exact, Float32,          false)
     test_splinevalue(s6, b6_exact, Float64,          false)
-    test_splinevalue(s6, b6_exact, Rational{Int},    true)
     # b7 = BSplineBasis(3, Int8[-6,-4,-2,0,0,1,2])
-    s7 = Spline(b7, view(1:10, 2:9))
-    test_splinevalue(s7, b7_exact, Int16,            false)
+    # s7 = Spline(b7, view(1:10, 2:9))
     test_splinevalue(s7, b7_exact, BigFloat,         false)
     test_splinevalue(s7, b7_exact, Rational{Int16},  true)
-    test_splinevalue(s7, b7_exact, Rational{Int128}, true)
 
     test_splinevalue_zero(s1, Inf16)
     test_splinevalue_zero(s2, -Inf32)
@@ -287,6 +264,12 @@
     test_splinevalue_nan(s4, big(NaN))
     test_splinevalue_nan(Spline(b4, fill(NaN, length(b4))), 1.5)
 
+    k = order(s5);
+    @test_throws DimensionMismatch splinevalue(s5, 0, workspace=zeros(k+1))
+    @test_throws DimensionMismatch splinevalue(s5, 0, workspace=zeros(k-1))
+    @test_throws DimensionMismatch splinevalue(s5, 0, workspace=zeros(1, k))
+    @test_throws DimensionMismatch splinevalue(s5, 0, workspace=zeros(k, 1))
+    @test_throws DimensionMismatch splinevalue(s5, 0, workspace=zeros(k, k))
     leftknot = intervalindex(basis(s5), 0)
     @test_throws ArgumentError splinevalue(s5, 0, leftknot=leftknot-1)
     @test_throws ArgumentError splinevalue(s5, 0, leftknot=leftknot+1)


### PR DESCRIPTION
This adds an optional keyword argument `workspace` to `splinevalue` to specify a pre-allocated vector for storing intermediate values, thus avoiding to allocate a new one each time.

```julia
julia> spl = Spline(BSplineBasis(4, 0:5), rand(8));

julia> work = zeros(order(spl));

julia> @btime $spl(2.5)
  125.765 ns (1 allocation: 112 bytes)
0.26257959122613184

julia> @btime $spl(2.5, workspace=$work)
  96.575 ns (0 allocations: 0 bytes)
0.26257959122613184
```