### PR TITLE
Fix iterator traits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 * ![Enhancement](https://img.shields.io/badge/-enhancement-blue) The default printing of `BSplineBasis` and `Spline` now uses the compact style for printing the breakpoint and coefficient vectors. ([#9](https://github.com/sostock/BSplines.jl/pull/9))
 
-* ![Bugfix](https://img.shields.io/badge/-bugfix-purple) The `IntervalIndices` iterator now implements `IteratorSize` and `eltype` correctly. ([#14](https://github.com/sostock/HalfIntegers.jl/pull/14))
+* ![Bugfix](https://img.shields.io/badge/-bugfix-purple) `BSplineBasis` and `IntervalIndices` now implement `IteratorSize` and `eltype` correctly. ([#14](https://github.com/sostock/HalfIntegers.jl/pull/14))
 
 ## v0.2.5
 

--- a/src/bsplinebasis.jl
+++ b/src/bsplinebasis.jl
@@ -42,7 +42,7 @@ Base.checkbounds(::Type{Bool}, b::BSplineBasis, i) = checkindex(Bool, eachindex(
 
 Base.eachindex(b::BSplineBasis) = Base.OneTo(lastindex(b))
 
-Base.eltype(b::BSplineBasis) = BSpline{typeof(b)}
+Base.eltype(T::Type{<:BSplineBasis}) = BSpline{T}
 
 Base.length(b::BSplineBasis) = Int(length(breakpoints(b))) + order(b) - 2
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -291,6 +291,7 @@ end
 
     @testset "Indexing and iteration" begin
         b1 = BSplineBasis(5, 0:5)
+        @test eltype(typeof(b1)) === BSpline{BSplineBasis{UnitRange{Int}}}
         @test collect(b1) == [b1[i] for i=1:9]
         @test @inferred(first(b1)) isa BSpline{BSplineBasis{UnitRange{Int}}}
         @test @inferred(last(b1)) isa BSpline{BSplineBasis{UnitRange{Int}}}
@@ -302,6 +303,7 @@ end
         @test_throws BoundsError b1[0]
         @test_throws BoundsError b1[10]
         b2 = BSplineBasis(3, [1,2,3.5,6,10])
+        @test eltype(typeof(b2)) === BSpline{BSplineBasis{Vector{Float64}}}
         @test collect(b2) == [b2[i] for i=1:6]
         @test @inferred(first(b2)) isa BSpline{BSplineBasis{Vector{Float64}}}
         @test @inferred(last(b2)) isa BSpline{BSplineBasis{Vector{Float64}}}


### PR DESCRIPTION
This PR fixes the implementation of `IntervalIndices` (`Base.IteratorSize` and `eltype` are supposed to take types as arguments, not instances).