### PR TITLE
Add support for `Iterators.reverse`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 * ![Feature](https://img.shields.io/badge/-feature-green) `splinevalue` now accepts a keyword argument `workspace` for providing a vector to store intermediate values in order to avoid unnecessary allocations. ([#10](https://github.com/sostock/BSplines.jl/pull/10))
 
+* ![Feature](https://img.shields.io/badge/-feature-green) `BSplineBasis` and `IntervalIndices` now support reverse iteration via `Iterators.reverse`. ([#15](https://github.com/sostock/BSplines.jl/pull/15))
+
 * ![Enhancement](https://img.shields.io/badge/-enhancement-blue) The default printing of `BSplineBasis` and `Spline` now uses the compact style for printing the breakpoint and coefficient vectors. ([#9](https://github.com/sostock/BSplines.jl/pull/9))
 
 * ![Bugfix](https://img.shields.io/badge/-bugfix-purple) `BSplineBasis` and `IntervalIndices` now implement `IteratorSize` and `eltype` correctly. ([#14](https://github.com/sostock/HalfIntegers.jl/pull/14))

--- a/src/bsplinebasis.jl
+++ b/src/bsplinebasis.jl
@@ -290,6 +290,21 @@ function Base.iterate(i::IntervalIndices, (index,value)=(first(i.indices),i.vec[
     return nothing
 end
 
+function Base.iterate(i::Iterators.Reverse{<:IntervalIndices})
+    isempty(i.itr.indices) && return nothing
+    index = last(i.itr.indices)
+    iterate(i, (index,i.itr.vec[index]))
+end
+function Base.iterate(i::Iterators.Reverse{<:IntervalIndices}, (index,value))
+    while index > first(i.itr.indices)
+        nextindex = index - 1
+        nextvalue = i.itr.vec[nextindex]
+        value > nextvalue && return (nextindex+i.itr.offset, (nextindex, nextvalue))
+        index = nextindex
+    end
+    return nothing
+end
+
 """
     intervalindices(basis::BSplineBasis, indices=eachindex(basis))
 

--- a/src/bsplinebasis.jl
+++ b/src/bsplinebasis.jl
@@ -40,8 +40,6 @@ function Base.checkbounds(b::BSplineBasis, i)
 end
 Base.checkbounds(::Type{Bool}, b::BSplineBasis, i) = checkindex(Bool, eachindex(b), i)
 
-Base.eachindex(b::BSplineBasis) = Base.OneTo(lastindex(b))
-
 Base.eltype(T::Type{<:BSplineBasis}) = BSpline{T}
 
 Base.length(b::BSplineBasis) = Int(length(breakpoints(b))) + order(b) - 2
@@ -51,12 +49,15 @@ Base.iterate(b::BSplineBasis, i=1) = i-1 < length(b) ? (@inbounds b[i], i+1) : n
 Base.firstindex(b::BSplineBasis) = 1
 Base.lastindex(b::BSplineBasis)  = length(b)
 
-Base.keys(b::BSplineBasis) = eachindex(b)
+Base.keys(b::BSplineBasis) = Base.OneTo(lastindex(b))
 
 @propagate_inbounds function Base.getindex(b::BSplineBasis, i::Integer)
     @boundscheck checkbounds(b, i)
     @inbounds BSpline(b, i)
 end
+
+Base.iterate(r::Iterators.Reverse{<:BSplineBasis}, i=length(r)) =
+    iszero(i) ? nothing : (@inbounds r.itr[i], i-1)
 
 function Base.show(io::IO, ::MIME"text/plain", basis::BSplineBasis)
     summary(io, basis); println(io, ':')

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -141,6 +141,7 @@ end
         @test intervalindices(basis, 2:4) == 3:6
         @test isempty(intervalindices(basis, 1:0))
         @test isempty(intervalindices(basis, 4:3))
+        @test isempty(intervalindices(basis, 100:99))
         for (i, irange) = support
             @test intervalindices(basis, i:i) == irange
             @test intervalindices(basis, i) == irange
@@ -176,6 +177,7 @@ end
     @test collect(intervalindices(basis, 5:6)) == [5,7,8,9]
     @test isempty(intervalindices(basis, 1:0))
     @test isempty(intervalindices(basis, 7:6))
+    @test isempty(intervalindices(basis, -100:-101))
     for (i, irange) = support
         @test collect(intervalindices(basis, i:i)) == irange
         @test collect(intervalindices(basis, i)) == irange
@@ -204,6 +206,7 @@ end
             @test Iterators.reverse(intervalindices(basis, 2:4)) == 6:-1:3
             @test isempty(Iterators.reverse(intervalindices(basis, 1:0)))
             @test isempty(Iterators.reverse(intervalindices(basis, 4:3)))
+            @test isempty(Iterators.reverse(intervalindices(basis, 100:99)))
             for (i, irange) = support
                 @test Iterators.reverse(intervalindices(basis, i:i)) == reverse(irange)
                 @test Iterators.reverse(intervalindices(basis, i)) == reverse(irange)
@@ -234,6 +237,7 @@ end
         @test collect(Iterators.reverse(intervalindices(basis, 5:6))) == [9,8,7,5]
         @test isempty(Iterators.reverse(intervalindices(basis, 1:0)))
         @test isempty(Iterators.reverse(intervalindices(basis, 7:6)))
+        @test isempty(Iterators.reverse(intervalindices(basis, -100:-101)))
         for (i, irange) = support
             @test collect(Iterators.reverse(intervalindices(basis, i:i))) == reverse(irange)
             @test collect(Iterators.reverse(intervalindices(basis, i))) == reverse(irange)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -353,6 +353,8 @@ end
     @testset "Indexing and iteration" begin
         b1 = BSplineBasis(5, 0:5)
         @test eltype(typeof(b1)) === BSpline{BSplineBasis{UnitRange{Int}}}
+        @test Base.IteratorEltype(typeof(b1)) === Base.HasEltype()
+        @test Base.IteratorSize(typeof(b1)) === Base.HasLength()
         @test collect(b1) == [b1[i] for i=1:9]
         @test @inferred(first(b1)) isa BSpline{BSplineBasis{UnitRange{Int}}}
         @test @inferred(last(b1)) isa BSpline{BSplineBasis{UnitRange{Int}}}
@@ -365,6 +367,8 @@ end
         @test_throws BoundsError b1[10]
         b2 = BSplineBasis(3, [1,2,3.5,6,10])
         @test eltype(typeof(b2)) === BSpline{BSplineBasis{Vector{Float64}}}
+        @test Base.IteratorEltype(typeof(b2)) === Base.HasEltype()
+        @test Base.IteratorSize(typeof(b2)) === Base.HasLength()
         @test collect(b2) == [b2[i] for i=1:6]
         @test @inferred(first(b2)) isa BSpline{BSplineBasis{Vector{Float64}}}
         @test @inferred(last(b2)) isa BSpline{BSplineBasis{Vector{Float64}}}
@@ -375,6 +379,29 @@ end
         @test b2[end] == Spline(b2, [0,0,0,0,0,1])
         @test_throws BoundsError b2[0]
         @test_throws BoundsError b2[7]
+
+        @testset "Iterators.reverse" begin
+            b1 = BSplineBasis(5, 0:5)
+            rb1 = Iterators.reverse(b1)
+            @test eltype(typeof(rb1)) === BSpline{BSplineBasis{UnitRange{Int}}}
+            @test Base.IteratorEltype(typeof(rb1)) === Base.HasEltype()
+            @test Base.IteratorSize(typeof(rb1)) === Base.HasLength()
+            @test collect(rb1) == [b1[i] for i=9:-1:1]
+            @test @inferred(first(rb1)) isa BSpline{BSplineBasis{UnitRange{Int}}}
+            @test @inferred(last(rb1)) isa BSpline{BSplineBasis{UnitRange{Int}}}
+            @test first(rb1) == Spline(b1, [0,0,0,0,0,0,0,0,1])
+            @test last(rb1) == Spline(b1, [1,0,0,0,0,0,0,0,0])
+            b2 = BSplineBasis(3, [1,2,3.5,6,10])
+            rb2 = Iterators.reverse(b2)
+            @test eltype(typeof(rb2)) === BSpline{BSplineBasis{Vector{Float64}}}
+            @test Base.IteratorEltype(typeof(rb2)) === Base.HasEltype()
+            @test Base.IteratorSize(typeof(rb2)) === Base.HasLength()
+            @test collect(rb2) == [b2[i] for i=6:-1:1]
+            @test @inferred(first(rb2)) isa BSpline{BSplineBasis{Vector{Float64}}}
+            @test @inferred(last(rb2)) isa BSpline{BSplineBasis{Vector{Float64}}}
+            @test first(rb2) == Spline(b2, [0,0,0,0,0,1])
+            @test last(rb2) == Spline(b2, [1,0,0,0,0,0])
+        end
     end
 
     @testset "breakpoints" begin


### PR DESCRIPTION
`BSplineBasis` and `IntervalIndices` now support reverse iteration with `Iterators.reverse`.