### PR TITLE
Add `derivspace` keyword

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 * ![Feature](https://img.shields.io/badge/-feature-green) `splinevalue` now accepts a keyword argument `workspace` for providing a vector to store intermediate values in order to avoid unnecessary allocations. ([#10](https://github.com/sostock/BSplines.jl/pull/10))
 
+* ![Feature](https://img.shields.io/badge/-feature-green) When calculating derivatives, `bsplines` and `bsplines!` now accept a keyword argument `derivspace` for providing a matrix to store intermediate values in order to avoid unnecessary allocations. ([#16](https://github.com/sostock/BSplines.jl/pull/16))
+
 * ![Feature](https://img.shields.io/badge/-feature-green) `BSplineBasis` and `IntervalIndices` now support reverse iteration via `Iterators.reverse`. ([#15](https://github.com/sostock/BSplines.jl/pull/15))
 
 * ![Enhancement](https://img.shields.io/badge/-enhancement-blue) The default printing of `BSplineBasis` and `Spline` now uses the compact style for printing the breakpoint and coefficient vectors. ([#9](https://github.com/sostock/BSplines.jl/pull/9))

--- a/docs/src/spline.md
+++ b/docs/src/spline.md
@@ -39,6 +39,30 @@ splinevalue(spl, 2.5, Derivative(2))
 !!! info
     The [`AllDerivatives{N}`](@ref) type is not supported as an argument.
 
+### Improving performance
+
+Two optional keyword arguments can be used to speed up the evaluation of splines:
+
+* `workspace`:
+  To evaluate a spline, a vector of length `order(spline)` is used to store intermediate values.
+  By default, a new vector is allocated for each evaluation.
+  To avoid this, a pre-allocated vector can be specified with the `workspace` keyword argument.
+  Note that in this case, the calculations are performed with numbers of type `eltype(workspace)`.
+* `leftknot`:
+  Evaluating a spline at a point `x` requires finding the largest index `i` such that `t[i] ≤ x` and `t[i] < t[end]` where `t` is the knot vector of the basis.
+  By default, the [`intervalindex`](@ref) function is used to find this index.
+  If the index is already known, it can be specified with the `leftknot` keyword argument.
+
+```@repl spline
+using BenchmarkTools
+spl = Spline(BSplineBasis(4, 0:5), rand(8));
+work = zeros(order(spl));
+left = intervalindex(basis(spl), 2.5);
+@btime $spl(2.5)
+@btime $spl(2.5, workspace=$work)
+@btime $spl(2.5, workspace=$work, leftknot=$left)
+```
+
 ## Arithmetic with `Spline`s
 
 A `Spline` can be multiplied or divided by a real number using `*`, `/`, or `\`.
@@ -92,26 +116,4 @@ bspl = b[3]
 spl == bspl
 support(spl) # support of the basis
 support(bspl) # actual support of the B-spline
-```
-
-## Performance considerations
-
-Two optional keyword arguments can be used to speed up the evaluation of splines:
-
-  * Evaluating a spline at a point `x` requires finding the largest index `i` such that `t[i] ≤ x` and `t[i] < t[end]` where `t` is the knot vector of the basis.
-    If the index is already known, it can be specified with the `leftknot` keyword argument.
-  * To evaluate a spline, a vector of length `order(spline)` is used to store intermediate values.
-    By default, a new vector is allocated for each evaluation.
-    To avoid this, a pre-allocated vector can be specified with the `workspace` keyword argument.
-    Note that in this case, the calculations are performed with numbers of type `eltype(workspace)`.
-
-```@repl spline
-using BenchmarkTools
-spl = Spline(BSplineBasis(4, 0:5), rand(8));
-left = intervalindex(basis(spl), 2.5);
-work = zeros(order(spl));
-@btime $spl(2.5)
-@btime $spl(2.5, leftknot=$left)
-@btime $spl(2.5, workspace=$work)
-@btime $spl(2.5, leftknot=$left, workspace=$work)
 ```

--- a/src/BSplines.jl
+++ b/src/BSplines.jl
@@ -3,7 +3,7 @@ module BSplines
 import LinearAlgebra
 
 using Base: @propagate_inbounds, has_offset_axes
-using LinearAlgebra: I, ldiv!, lmul!, rdiv!, rmul!
+using LinearAlgebra: I, diagind, ldiv!, lmul!, rdiv!, rmul!
 using OffsetArrays: OffsetArray
 
 export

--- a/src/bsplinebasis.jl
+++ b/src/bsplinebasis.jl
@@ -430,7 +430,7 @@ julia> support(BSplineBasis(4, [1.0, 1.5, 2.5, 4.0]))
 support(b::BSplineBasis) = (bps = breakpoints(b); (first(bps), last(bps)))
 
 """
-    bsplines(basis, x, [::Derivative{N}]; leftknot=intervalindex(basis, x))
+    bsplines(basis, x, [::Derivative{N}]; kwargs...)
 
 Calculate the values of all non-zero B-splines of `basis`, or their `N`-th derivatives, at
 `x`.
@@ -439,8 +439,16 @@ If any B-splines are non-zero at `x`, return an `OffsetVector` that contains the
 the `i`-th B-spline (or its `N`-th derivative) at the index `i`. If no B-splines are
 non-zero at `x`, return `nothing`.
 
-If the index of the relevant interval is already known, it can be supplied with the optional
-`leftknot` keyword to speed up the calculation.
+Two optional keyword arguments can be used to increase performance:
+* `leftknot`: If the index of the relevant interval (i.e.,
+  `intervalindex(basis(spline), x)`) is already known, it can be supplied with the
+  `leftknot` keyword.
+* `derivspace`: When calculating derivatives, some coefficients are stored in a matrix of
+  size `(order(basis), order(basis))`. By default, the function allocates a new matrix. To
+  avoid this, a pre-allocated matrix can be supplied with the `derivspace` keyword. It can
+  only be used when calculating derivatives, i.e., with `Derivative(N)` where `N ≥ 1` or
+  `AllDerivatives(N)` where `N ≥ 2`. To also pre-allocate the vector that contains the
+  result, use the [`bsplines!`](@ref) function instead.
 
 # Examples
 
@@ -454,7 +462,7 @@ julia> bsplines(basis, 2.4)
  0.41466666666666663
  0.01066666666666666
 
-julia> bsplines(basis, 2.4, Derivative(1))
+julia> bsplines(basis, 2.4, Derivative(1), derivspace=zeros(4,4))
 4-element OffsetArray(::Array{Float64,1}, 3:6) with eltype Float64 with indices 3:6:
  -0.18000000000000005
  -0.5599999999999999
@@ -482,21 +490,32 @@ If any B-splines are non-zero at `x`, return an `OffsetMatrix` that contains the
 derivative of the `i`-th B-spline at the index `i, m`. If no B-splines are non-zero at `x`,
 return `nothing`.
 
-If the index of the relevant interval is already known, it can be supplied with the optional
-`leftknot` keyword to speed up the calculation.
+Two optional keyword arguments can be used to increase performance:
+* `leftknot`: If the index of the relevant interval (i.e.,
+  `intervalindex(basis(spline), x)`) is already known, it can be supplied with the
+  `leftknot` keyword.
+* `derivspace`: When calculating derivatives, some coefficients are stored in a matrix of
+  size `(order(basis), order(basis))`. By default, the function allocates a new matrix. To
+  avoid this, a pre-allocated matrix can be supplied with the `derivspace` keyword. It can
+  only be used when calculating derivatives, i.e., with `Derivative(N)` where `N ≥ 1` or
+  `AllDerivatives(N)` where `N ≥ 2`. To also pre-allocate the vector that contains the
+  result, use the [`bsplines!`](@ref) function instead.
 
 # Examples
 
 ```jldoctest
-julia> bsplines(BSplineBasis(3, 0:5), 2.4, AllDerivatives(3))
-3×3 OffsetArray(::Array{Float64,2}, 3:5, 0:2) with eltype Float64 with indices 3:5×0:2:
- 0.18  -0.6   1.0
- 0.74   0.2  -2.0
- 0.08   0.4   1.0
+julia> basis = BSplineBasis(4, 0:5);
 
-julia> bsplines(BSplineBasis(3, 0:5), 6.0, AllDerivatives(3)) # returns nothing
+julia> bsplines(basis, 2.4, AllDerivatives(3))
+4×3 OffsetArray(::Array{Float64,2}, 3:6, 0:2) with eltype Float64 with indices 3:6×0:2:
+ 0.036      -0.18   0.6
+ 0.538667   -0.56  -0.8
+ 0.414667    0.66  -0.2
+ 0.0106667   0.08   0.4
 
-julia> bsplines(BSplineBasis(4, 0:5), 17//5, AllDerivatives(4), leftknot=7)
+julia> bsplines(basis, 6.0, AllDerivatives(3)) # returns nothing
+
+julia> bsplines(basis, 17//5, AllDerivatives(4), leftknot=7)
 4×4 OffsetArray(::Array{Rational{Int64},2}, 4:7, 0:3) with eltype Rational{Int64} with indices 4:7×0:3:
    9//250   -9//50   3//5  -1//1
  202//375  -14//25  -4//5   3//1
@@ -517,8 +536,15 @@ If any B-splines are non-zero at `x`, return an `OffsetVector` that wraps `dest`
 contains the value of the `i`-th B-spline (or its `N`-th derivative) at the index `i`. If no
 B-splines are non-zero at `x`, return `nothing`.
 
-If the index of the relevant interval is already known, it can be supplied with the optional
-`leftknot` keyword to speed up the calculation.
+Two optional keyword arguments can be used to increase performance:
+* `leftknot`: If the index of the relevant interval (i.e.,
+  `intervalindex(basis(spline), x)`) is already known, it can be supplied with the
+  `leftknot` keyword.
+* `derivspace`: When calculating derivatives, some coefficients are stored in a matrix of
+  size `(order(basis), order(basis))`. By default, the function allocates a new matrix. To
+  avoid this, a pre-allocated matrix can be supplied with the `derivspace` keyword. It can
+  only be used when calculating derivatives, i.e., with `Derivative(N)` where `N ≥ 1` or
+  `AllDerivatives(N)` where `N ≥ 2`.
 
 # Examples
 
@@ -549,8 +575,15 @@ If any B-splines are non-zero at `x`, return an `OffsetMatrix` that wraps `dest`
 contains the `m`-th derivative of the `i`-th B-spline at the index `i, m`. If no B-splines
 are non-zero at `x`, return `nothing`.
 
-If the index of the relevant interval is already known, it can be supplied with the optional
-`leftknot` keyword to speed up the calculation.
+Two optional keyword arguments can be used to increase performance:
+* `leftknot`: If the index of the relevant interval (i.e.,
+  `intervalindex(basis(spline), x)`) is already known, it can be supplied with the
+  `leftknot` keyword.
+* `derivspace`: When calculating derivatives, some coefficients are stored in a matrix of
+  size `(order(basis), order(basis))`. By default, the function allocates a new matrix. To
+  avoid this, a pre-allocated matrix can be supplied with the `derivspace` keyword. It can
+  only be used when calculating derivatives, i.e., with `Derivative(N)` where `N ≥ 1` or
+  `AllDerivatives(N)` where `N ≥ 2`.
 
 # Examples
 


### PR DESCRIPTION
This adds the `derivspace` keyword argument to `bsplines` and `bsplines!` for pre-allocation of the matrix that stores the coefficients needed to evaluate derivatives.