### PR TITLE
Simplify docs

### DIFF
--- a/docs/src/spline.md
+++ b/docs/src/spline.md
@@ -58,9 +58,9 @@ using BenchmarkTools
 spl = Spline(BSplineBasis(4, 0:5), rand(8));
 work = zeros(order(spl));
 left = intervalindex(basis(spl), 2.5);
-@btime $spl(2.5)
-@btime $spl(2.5, workspace=$work)
-@btime $spl(2.5, workspace=$work, leftknot=$left)
+@btime $spl(2.5);
+@btime $spl(2.5, workspace=$work);
+@btime $spl(2.5, workspace=$work, leftknot=$left);
 ```
 
 ## Arithmetic with `Spline`s

--- a/src/spline.jl
+++ b/src/spline.jl
@@ -160,22 +160,22 @@ support(s::Spline) = support(basis(s))
 support(b::BSpline) = (t = knots(basis(b)); i = coeffs(b).index; (t[i], t[i+order(b)]))
 
 """
-    splinevalue(spline::Spline, x, [::Derivative{N}]; kwargs...)
+    splinevalue(spline::Spline, x[, ::Derivative{N}]; kwargs...)
 
 Calculate the value of `spline`, or its `N`-th derivative, at `x`.
 
 Two optional keyword arguments can be used to increase performance:
-* `leftknot`: If the index of the relevant interval (i.e.,
-  `intervalindex(basis(spline), x)`) is already known, it can be supplied with the
-  `leftknot` keyword.
 * `workspace`: By default, the function allocates a vector of length `order(spline)` in
   which the calculation is performed. To avoid this, a pre-allocated vector can be supplied
   with the `workspace` keyword. In this case, the returned value is always of type
   `eltype(workspace)`.
+* `leftknot`: If the index of the relevant interval (i.e.,
+  `intervalindex(basis(spline), x)`) is already known, it can be supplied with the
+  `leftknot` keyword.
 
 Instead of calling `splinevalue`, a spline object can be called directly:
-`spline(x, [deriv]; kwargs...)` is equivalent to
-`splinevalue(spline, x, [deriv]; kwargs...)`.
+`spline(x[, Derivative(N)]; kwargs...)` is equivalent to
+`splinevalue(spline, x[, Derivative(N)]; kwargs...)`.
 
 # Examples
 


### PR DESCRIPTION
The two docstrings for `bsplines` are merged, the same for `bsplines!`. Some examples in the manual are shortened (we only need the timing, not the returned value).