### PR TITLE
Add clarification about k to docs

### DIFF
--- a/docs/src/basis.md
+++ b/docs/src/basis.md
@@ -10,6 +10,13 @@ A B-spline basis is completely characterized by its order ``k`` and knot vector 
 In the case of the `BSplineBasis` type, **the knot vector of a basis is generated from its breakpoint vector by repeating the first and last breakpoints so that they appear ``k`` times.**
 
 !!! note
+    In this package, ``k`` always refers to the *order* of a B-spline. Some B-spline libraries, including DIERCKX and scipy.interpolate, use the symbol ``k`` to refer to the *degree* of a B-spline. The relationship between the two is
+    ```math
+    \mathrm{order} = \mathrm{degree} + 1.
+    ```
+    For example, using ``k=4`` in this package is equivalent to ``k=3`` (cubic splines) in scipy.interpolate.
+
+!!! note
     Knot sequences where the first and last knot do not appear ``k`` times are not supported by the `BSplineBasis` type.
     The reason for this is that it simplifies the evaluation of B-splines, since it means that exactly ``k`` B-splines are non-zero on each interval.
     If the first or last knot would appear less than ``k`` times, this would not be the case.

--- a/src/bsplinebasis.jl
+++ b/src/bsplinebasis.jl
@@ -7,6 +7,9 @@ Here, a B-spline basis is completely specified by its order ``k`` and breakpoint
 The knot sequence is derived from the breakpoint sequence by duplicating the first and last
 breakpoints so they each appear ``k`` times. Knot sequences where the first and last
 breakpoints do not appear ``k`` times are not supported by this data type.
+
+!!! note
+    Here, unlike in some other B-spline libraries, ``k`` always refers to the *order* of a B-spline, not its *degree* (order = degree + 1).
 """
 struct BSplineBasis{T<:AbstractVector{<:Real}}
     order::Int


### PR DESCRIPTION
Emphasize in the documentation that *k* refers to the order, not the degree of a spline. One note is added at the beginning of the manual and a shorter one in the `BSplineBasis` docstring.

Fixes #20.